### PR TITLE
Task 4: SCA/SAST, DAST, konfiguracja CI/CD

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,34 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  security-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build Docker image
+        run: |
+          docker build -t myapp:latest .
+
+      - name: Run Trivy scan
+        uses: aquasecurity/trivy-action@v0.10.0
+        with:
+          image-ref: 'myapp:latest'
+          vuln-type: 'os,library'
+          format: 'table'
+
+      - name: Install Semgrep
+        run: |
+          sudo pip install semgrep
+
+      - name: Run Semgrep SAST
+        run: |
+          semgrep --config p/security-audit --error --json .

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -19,7 +19,7 @@ jobs:
           docker build -t myapp:latest .
 
       - name: Run Trivy scan
-        uses: aquasecurity/trivy-action@v0.10.0
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: 'myapp:latest'
           vuln-type: 'os,library'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -25,9 +25,21 @@ jobs:
           vuln-type: 'os,library'
           format: 'table'
 
+      - name: Install venv for Semgrep
+        run: |
+          sudo apt install python3.12-venv
+
+      - name: Create venv for Semgrep
+        run: |
+          python3 -m venv ./venv
+
+      - name: Activate Semgrep venv
+        run: |
+          source ./venv/bin/activate
+
       - name: Install Semgrep
         run: |
-          sudo pip install semgrep
+          pip install semgrep
 
       - name: Run Semgrep SAST
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY pom.xml /app
 RUN mvn clean install -DskipTests
 
 # ---- Deploy Stage ----
-FROM openjdk:11-jdk-slim
+FROM openjdk:11.0.13-jdk-slim
 
 # Copy the built JAR from the build stage
 COPY --from=build /app/target/thymeleaf-0.0.1-SNAPSHOT.jar /app.jar


### PR DESCRIPTION
# Zadanie 1.
Aby zbudowanie obrazu udało się, zamieniłem w Dockerfile użyty obraz openjdk na `openjdk:11.0.13-jdk-slim`.
Po uruchomieniu Trivy narzędzie pobrało odpowiednie zależności do analizy i sporządziło raport, w którym wymienione są podatności nie tylko samego jara aplikacji i jej zależności, ale też kontenera w środku którego aplikacja zostaje uruchomiona. W raporcie znajdują się podatności dla danych pakietów systemowych i artefaktów Javy, razem z powiązanymi CVE, na poziomach `LOW`, `MEDIUM`, `HIGH` oraz `CRITICAL`, z podanym statusem (m. in affected, fixed, fix_deferred), wersją znalezioną w kontenerze, wersją w której podatność (jeżeli tak się stało) została usunięta, oraz krótkim opisem podatności oraz linkiem do szczegółów. Pełny raport znajduje się w dołączonym pliku [trivyreport.txt](https://github.com/user-attachments/files/24178798/trivyreport.txt). 

# Zadanie 2.
Semgrep zwrócił raport z listą miejsc w kodzie z potencjalnymi błędami lub podatnościami, do każdego z nich dołączony jest opis błędu oraz link do bazy online w której błędy są formalnie opisane razem ze wzorcami je wykrywającymi. Wygenerowany raport znajduje się w pliku [semgrepreport.txt](https://github.com/user-attachments/files/24178802/semgrepreport.txt)

# Zadanie 3.
Utworzony na podstawie podanego przykładu workflow został zapisany w pliku `.github/workflows/security-scan.yml`. Instrukcje zostały zmodyfikowane w taki sposób, aby Semgrep instalowany był w środowisku venv, gdyż instalacja bezpośrednio w systemie utykała na błędzie w trakcie instalacji zależności. Wynik przeprowadzonego skanu znajduje się w [tym podsumowaniu uruchomienia akcji](https://github.com/B1rtek/task4/actions/runs/20216355305/job/58029925200). Akcja zakończyła się błędem, gdyż Semgrep znalazł 26 błędów "blokujących".

# Zadanie 4.

Narzędzie Zaproxy uruchomiłem z instalacji lokalnej. Po zakończeniu skanu wygenerowałem raport, w którym znalazły się następujące wyniki: 
<img width="785" height="751" alt="obraz" src="https://github.com/user-attachments/assets/368a7fb4-779f-4eda-918a-371a710f850c" />
Znalezione zostało 9 rodzajów błędów w kilku różnych zapytaniach i interakcjach ze stroną. Żaden z alertów nie uzyskał oceny ryzyka na poziomie wysokim. Pełny raport znajduje się w pliku [zap_report.html](https://github.com/user-attachments/files/24178803/zap_report.html).
Podatności lub błędy znalezione przez ZAP różnią się od tych wykrytych przez Trivy oraz Semgrep, gdyż ZAP testuje gotową aplikację będącą efektem integracji wszystkich elementów składowych, a zatem wyłapuje błędy w konfiguracji elementów i ich interakcjach, a nie błędy znajdujące się w nich samych. Znalezienie innych rodzajów błędów wynika również z techniki skanu - narzędzia SAST i SCA miały dostęp do kodu i kontenera, ZAP będący narzędziem DAST tego dostępu nie ma.