### PR TITLE
Lab 4

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -19,7 +19,7 @@ jobs:
           docker build -t task4-python:latest .
 
       - name: Run Trivy scan
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: 'task4-python:latest'
           vuln-type: 'os,library'

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,0 +1,39 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  security-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build -t task4-python:latest .
+
+      - name: Run Trivy scan
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: 'task4-python:latest'
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          format: 'table'
+          exit-code: '0'
+
+      - name: Install Semgrep
+        run: |
+          pip install semgrep
+
+      - name: Run Semgrep SAST
+        run: |
+          semgrep scan \
+            --config p/security-audit \
+            --error \
+            .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ COPY pom.xml /app
 RUN mvn clean install -DskipTests
 
 # ---- Deploy Stage ----
-FROM openjdk:11-jdk-slim
+# FROM openjdk:11-jdk-slim
+FROM amazoncorretto:11-alpine
 
 # Copy the built JAR from the build stage
 COPY --from=build /app/target/thymeleaf-0.0.1-SNAPSHOT.jar /app.jar


### PR DESCRIPTION
## Zad 1

Ponieważ były problemy z uruchomieniem to delikatnie zmieniono docker file.
Przykładowe zwrócenie przez trivy:

`Total: 6 (UNKNOWN: 0, LOW: 3, MEDIUM: 3, HIGH: 0, CRITICAL: 0)`

├──────────────────────────────────────────────────────────────┼──────────────────┼──────────┤        ├───────────────────┼─────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.thymeleaf:thymeleaf-spring5 (app.jar)                    │ CVE-2021-43466   │ CRITICAL │        │ 3.0.12.RELEASE    │ 3.0.13.RELEASE                      │ Template injection in thymeleaf-spring5                      │
│                                                              │                  │          │        │                   │                                     │ https://avd.aquasec.com/nvd/cve-2021-43466                   │
├──────────────────────────────────────────────────────────────┼──────────────────┼──────────┤        ├───────────────────┼─────────────────────────────────────┼───────────────────────────────────────────────

│ org.springframework:spring-webmvc (app.jar)                  │ CVE-2022-22965   │ CRITICAL │        │                   │ 5.2.20.RELEASE, 5.3.18              │ spring-framework: RCE via Data Binding on JDK 

## Zad 2

┌──────────────┐
│ Scan Summary │
└──────────────┘
✅ Scan completed successfully.
 • Findings: 26 (26 blocking)
 • Rules run: 445
 • Targets scanned: 1793
 • Parsed lines: ~100.0%
 • Scan skipped:
   ◦ Files larger than  files 1.0 MB: 2
   ◦ Files matching .semgrepignore patterns: 30
 • Scan was limited to files tracked by git
 • For a detailed list of skipped files and lines, run semgrep with the --verbose flag
Ran 445 rules on 1793 files: 26 findings.

# Obowiązkowe

## Zad 3

Konfiguracja pliku:

```yml
name: Security Scan

on:
  push:
    branches: [ "main" ]
  pull_request:
    branches: [ "main" ]

jobs:
  security-tests:
    runs-on: ubuntu-latest

    steps:
      - name: Check out code
        uses: actions/checkout@v4

      - name: Build Docker image
        run: |
          docker build -t task4-python:latest .

      - name: Run Trivy scan
        uses: aquasecurity/trivy-action@0.33.1
        with:
          image-ref: 'task4-python:latest'
          vuln-type: 'os,library'
          severity: 'CRITICAL,HIGH'
          format: 'table'
          exit-code: '0'

      - name: Install Semgrep
        run: |
          pip install semgrep

      - name: Run Semgrep SAST
        run: |
          semgrep scan \
            --config p/security-audit \
            --error \
            .
```

[Skończony job](https://github.com/domikkkk/task4/actions/runs/20756267758/job/59599106688)

## Zad 4

Po uruchomieniu ZAPa i przeskanowaniu aplikacji:

`FAIL-NEW: 0     FAIL-INPROG: 0  WARN-NEW: 12    WARN-INPROG: 0  INFO: 0 IGNORE: 0       PASS: 55`

<img width="1884" height="889" alt="image" src="https://github.com/user-attachments/assets/92f9316f-0eb6-4de1-864e-527728b53940" />

Narzędzie wykryło podatności niewidoczne w SAST i SCA, takie jak brak nagłówków bezpieczeństwa HTTP, brak ochrony CSRF oraz nieprawidłowe zarządzanie sesją (np. jsessionid w URL). Problemy te nie zostały wykryte przez Semgrep i Trivy, ponieważ SAST analizuje wyłącznie kod źródłowy, a SCA jedynie zależności i obraz kontenerowy. OWASP ZAP, jako narzędzie DAST, testuje działającą aplikację i analizuje jej rzeczywiste odpowiedzi HTTP. Różnice w wynikach wynikają z analizy aplikacji na różnych etapach jej cyklu życia.
